### PR TITLE
Consider the current year and week context

### DIFF
--- a/statistics.py
+++ b/statistics.py
@@ -144,13 +144,13 @@ def main():
     from_date = None
     if args.interval == 'day':
         interval = args.interval
-        from_date = pendulum.now().subtract(days=30).format('YYYY-MM-DD')
+        from_date = pendulum.now().subtract(days=1).format('YYYY-MM-DD')
     if args.interval == 'week':
         interval = args.interval
-        from_date = pendulum.now().subtract(days=120).format('YYYY-MM-DD')
+        from_date = pendulum.now().start_of('week').subtract(days=1).format('YYYY-MM-DD')
     if args.interval == 'year':
         interval = None
-        from_date = pendulum.now().subtract(days=365).format('YYYY-MM-DD')
+        from_date = pendulum.now().format('YYYY-01-01')
     if args.from_date:
         from_date = args.from_date
 


### PR DESCRIPTION
Consider the current year and week context if no start date is specified.

I currently find it a bit confusing to simply subtract 120, or 365 days from the current date if no start date has been specified for the calculations.
Thus the results in calculations sometimes do not refer to the current year, or complete weeks.
I would therefore suggest to display only the current week or the current year, if no exact start date was specified.

Greetings
Simon