### PR TITLE
Support Plus Codes type of addresses (single address element)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.9] - 2022-07-04
+
+### Fixed
+
+- Support Plus Codes type of addresses (single address element)
+
 ## [0.0.8] - 2022-04-03
 
 ### Fixed

--- a/tojota.py
+++ b/tojota.py
@@ -21,7 +21,6 @@ import os
 from pathlib import Path
 import platform
 import sys
-import uuid
 
 import pendulum
 import requests
@@ -461,8 +460,14 @@ def main():
             end = trip['endAddress'].split(',')
         except KeyError:
             end = ['Unknown', ' Unknown']
-        start_address = '{},{}'.format(start[0], start[1])
-        end_address = '{},{}'.format(end[0], end[1])
+        try:
+            start_address = '{},{}'.format(start[0], start[1])
+        except IndexError:
+            start_address = start[0]
+        try:
+            end_address = '{},{}'.format(end[0], end[1])
+        except IndexError:
+            end_address = end[0]
         kms += stats['totalDistanceInKm']
         ls += stats['fuelConsumptionInL']
         average_consumption = (stats['fuelConsumptionInL']/stats['totalDistanceInKm'])*100


### PR DESCRIPTION
Don't crash when encountering address like 9GW9M43Q+CR.